### PR TITLE
Support ruby 3.1.3 over

### DIFF
--- a/serverspec-runner.gemspec
+++ b/serverspec-runner.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
   
   spec.add_runtime_dependency     "serverspec"
   spec.add_runtime_dependency     "net-ssh"
-  spec.add_runtime_dependency     'psych'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-core"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
 end


### PR DESCRIPTION
- Removed version restrictions on bundler.
- Removed an error in the psych installation because the gem itself was not needed.